### PR TITLE
페이지 공통 좌우 여백 container 추가 및 헤더 UI 개발

### DIFF
--- a/components/common/Container.tsx
+++ b/components/common/Container.tsx
@@ -1,0 +1,34 @@
+import styled, { css } from "styled-components";
+
+interface ContainerProps {
+  readonly isAlignCenter?: boolean;
+}
+
+export default styled.div<ContainerProps>`
+  ${({ theme, isAlignCenter }) => {
+    const { media } = theme;
+    return css`
+      width: 100%;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding-inline: 20px;
+
+      ${isAlignCenter &&
+      css`
+        text-align: center;
+      `}
+
+      ${media.sm} {
+        padding-inline: 30px;
+      }
+
+      ${media.md} {
+        padding-inline: 40px;
+      }
+
+      ${media.xl} {
+        width: 100%;
+      }
+    `;
+  }}
+`;

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -1,19 +1,51 @@
+import Container from "components/common/Container";
 import styled, { css } from "styled-components";
+import logo from "assets/images/logo.png";
 
 export default function Header() {
   return (
     <>
-      <S.Container>Header</S.Container>
+      <S.Header>
+        <Container>
+          <S.Logo href="/">
+            <img src={logo.src} alt="Itsuda" />
+          </S.Logo>
+        </Container>
+      </S.Header>
     </>
   );
 }
 
 const S = {
-  Container: styled.div`
+  Header: styled.div`
     ${({ theme }) => {
+      const { colors } = theme;
       return css`
-        color: ${theme.colors.blue_1};
+        position: sticky;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        top: 0;
+        height: 72px;
+        background-color: ${colors["dark_1"]};
+        border-bottom: 1px solid ${colors["gray_2"]};
+        z-index: 1;
       `;
     }}
+  `,
+  Logo: styled.a`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    width: 52px;
+    height: 52px;
+
+    > img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
   `,
 };

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -1,10 +1,22 @@
-import { createGlobalStyle } from "styled-components";
+import { createGlobalStyle, css } from "styled-components";
 import reset from "styled-reset";
 
 export default createGlobalStyle`
   ${reset}
-  body {
-    font-family: Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-      Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  }
+  ${({ theme }) => {
+    const { colors } = theme;
+    return css`
+      body {
+        font-family: Arial, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
+          sans-serif;
+        min-height: 100vh;
+        background-color: ${colors["dark_1"]};
+        color: ${colors["white"]};
+      }
+      * {
+        box-sizing: border-box;
+      }
+    `;
+  }}
 `;

--- a/styles/styled.d.ts
+++ b/styles/styled.d.ts
@@ -1,10 +1,29 @@
 import "styled-components";
-import { colors } from "./theme";
+import { theme } from "./theme";
 
-type ColorsTypes = typeof colors;
+type ColorsTypes = typeof theme.colors;
 
 declare module "styled-components" {
   export interface DefaultTheme {
-    colors: ColorsTypes;
+    media: {
+      readonly xs: string;
+      readonly sm: string;
+      readonly md: string;
+      readonly lg: string;
+      readonly xl: string;
+    };
+    colors: {
+      readonly white: string;
+      readonly black: string;
+      readonly lightgray_1: string;
+      readonly lightgray_2: string;
+      readonly gray_1: string;
+      readonly gray_2: string;
+      readonly gray_3: string;
+      readonly dark_1: string;
+      readonly dark_2: string;
+      readonly red_1: string;
+      readonly blue_1: string;
+    };
   }
 }

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,6 +1,20 @@
 import { DefaultTheme } from "styled-components";
 
+const mediaSizes = {
+  sm: 380,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+};
+
 export const theme: DefaultTheme = {
+  media: {
+    xs: `@media only screen and (max-width: ${mediaSizes.sm}px)`, // ~ 380
+    sm: `@media only screen and (min-width: ${mediaSizes.sm}px)`, // 380 ~
+    md: `@media only screen and (min-width: ${mediaSizes.md}px)`, // 768 ~
+    lg: `@media only screen and (min-width: ${mediaSizes.lg}px)`, // 1024 ~
+    xl: `@media only screen and (min-width: ${mediaSizes.xl}px)`, // 1280 ~
+  },
   colors: {
     white: "#ffffff",
     black: "#000000",


### PR DESCRIPTION
### 작업 내용
- 반응형 대응을 위한 미디어쿼리 추가
- 페이지 공통 좌우 여백 container 추가
   - `max-width: 1200px;`
   - 브라우저 사이즈에 따라 좌우 `padding` 값 조절
- 헤더 UI 개발
   - 좌측 - 서비스 로고 출력
   - 페이지 하단으로 스크롤시 화면 상단에 고정 노출 처리

### 스크린샷
![1](https://user-images.githubusercontent.com/33195744/198875677-dabba0b7-e050-4315-abf9-e28021e9af0f.gif)
