### PR TITLE
Footer 추가

### DIFF
--- a/components/banner/index.tsx
+++ b/components/banner/index.tsx
@@ -1,3 +1,11 @@
+import styled from "styled-components";
+
 export default function Banner() {
-  return <>Banner</>;
+  return <S.Banner>Banner</S.Banner>;
 }
+
+const S = {
+  Banner: styled.div`
+    height: 100vh;
+  `,
+};

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -1,3 +1,77 @@
+import styled, { css } from "styled-components";
+import logo from "assets/images/logo.png";
+import { helpMail } from "data/links";
+import Container from "components/common/Container";
+import Link from "next/link";
+
 export default function Footer() {
-  return <>Footer</>;
+  return (
+    <S.Footer>
+      <Container>
+        <S.Contents>
+          <S.Logo>
+            <Link href="/">
+              <img src={logo.src} alt="Itsuda" />
+            </Link>
+            <span>© 2022 Itsuda</span>
+          </S.Logo>
+          <S.Nav>
+            <a href={helpMail}>문의하기</a>
+          </S.Nav>
+        </S.Contents>
+      </Container>
+    </S.Footer>
+  );
 }
+
+const S = {
+  Footer: styled.div`
+    ${({ theme }) => {
+      const { colors } = theme;
+      return css`
+        display: flex;
+        justify-content: space-between;
+        height: 100px;
+        background-color: ${colors["dark_1"]};
+        color: ${colors["lightgray_2"]};
+        font-size: 14px;
+        margin-bottom: 70px;
+      `;
+    }}
+  `,
+  Contents: styled.div`
+    ${({ theme }) => {
+      const { colors } = theme;
+      return css`
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        height: 100%;
+        border-top: 1px solid ${colors["gray_2"]};
+      `;
+    }}
+  `,
+  Logo: styled.div`
+    display: flex;
+    align-items: center;
+    gap: 5px;
+
+    a {
+      img {
+        width: 40px;
+        height: 40px;
+        object-fit: contain;
+        opacity: 0.6;
+
+        &:hover {
+          opacity: 0.7;
+        }
+      }
+    }
+  `,
+  Nav: styled.nav`
+    display: flex;
+    align-items: center;
+    padding-inline: 5px;
+  `,
+};

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -4,15 +4,13 @@ import logo from "assets/images/logo.png";
 
 export default function Header() {
   return (
-    <>
-      <S.Header>
-        <Container>
-          <S.Logo href="/">
-            <img src={logo.src} alt="Itsuda" />
-          </S.Logo>
-        </Container>
-      </S.Header>
-    </>
+    <S.Header>
+      <Container>
+        <S.Logo href="/">
+          <img src={logo.src} alt="Itsuda" />
+        </S.Logo>
+      </Container>
+    </S.Header>
   );
 }
 

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -17,6 +17,10 @@ export default createGlobalStyle`
       * {
         box-sizing: border-box;
       }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
     `;
   }}
 `;


### PR DESCRIPTION
### 작업 내용
- Footer 개발
   - 좌측 서비스 로고 (메인 화면으로 이동)
   - 우측 문의하기 버튼 추가 (이메일 작성 링크로 이동)
- Footer UI 확인을 위한 Banner height 임시 지정
- Header 불필요한 코드 제거

### 스크린샷
![1](https://user-images.githubusercontent.com/33195744/198876454-4181532b-8679-4005-b16a-24c030a8faae.gif)
