### PR TITLE
메인 페이지 배너 추가

### DIFF
--- a/components/banner/index.tsx
+++ b/components/banner/index.tsx
@@ -1,11 +1,61 @@
-import styled from "styled-components";
+import banners from "data/banners";
+import { useEffect, useState } from "react";
+import S from "./style";
 
 export default function Banner() {
-  return <S.Banner>Banner</S.Banner>;
-}
+  const intervalTime: number = 2000;
+  const [currentIndex, setCurrentIndex] = useState<number>(0);
 
-const S = {
-  Banner: styled.div`
-    height: 100vh;
-  `,
-};
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (currentIndex >= banners.length - 1) {
+        setCurrentIndex(0);
+      } else {
+        setCurrentIndex((currentIndex) => currentIndex + 1);
+      }
+    }, intervalTime);
+    return () => clearInterval(timer);
+  }, [currentIndex]);
+
+  const getState = (i: number) => {
+    if (i === currentIndex) {
+      return "current";
+    } else if (
+      i === currentIndex + 1 ||
+      (currentIndex === banners.length - 1 && i === 0)
+    ) {
+      return "next";
+    } else if (
+      i === currentIndex - 1 ||
+      (currentIndex === 0 && i === banners.length - 1)
+    ) {
+      return "prev";
+    } else {
+      return "hidden";
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.Banner
+        image={banners[currentIndex].image.src}
+        bgColor={banners[currentIndex].bgColor}
+      >
+        <S.Contents>
+          잇수다에는
+          <p>
+            <S.Box>
+              {banners.map(({ name }, index) => (
+                <S.Name key={index} state={getState(index)}>
+                  {name}
+                </S.Name>
+              ))}
+            </S.Box>
+            를 위한
+          </p>
+          이벤트 잇수다
+        </S.Contents>
+      </S.Banner>
+    </S.Container>
+  );
+}

--- a/components/banner/style.tsx
+++ b/components/banner/style.tsx
@@ -1,0 +1,130 @@
+import styled, { css } from "styled-components";
+
+export default {
+  Container: styled.div`
+    ${({ theme }) => {
+      const { media } = theme;
+      return css`
+        margin: 0 auto;
+        max-width: 1200px;
+
+        ${media.md} {
+          padding: 40px;
+        }
+
+        ${media.lg} {
+          padding: 50px 40px;
+        }
+      `;
+    }}
+  `,
+  Banner: styled.div<{ image: string; bgColor: string }>`
+    ${({ theme, image, bgColor }) => {
+      const { media } = theme;
+      return css`
+        display: flex;
+        width: 100%;
+        height: 300px;
+        background-size: auto 80%;
+        border-radius: 0;
+        margin: 0 auto;
+        padding: 20px;
+        background-repeat: no-repeat;
+        background-position: right bottom;
+        align-items: flex-start;
+        background-size: 80%;
+        background-image: url(${image});
+        background-color: ${bgColor};
+
+        ${media.sm} {
+          height: 370px;
+          padding: 30px 30px 30px 40px;
+          background-size: 60%;
+        }
+
+        ${media.md} {
+          align-items: center;
+          border-radius: 25px;
+          padding: 50px 50px 50px 60px;
+          background-repeat: no-repeat;
+          background-position: right bottom;
+          transition: background-color 0.3s;
+          background-size: auto 60%;
+        }
+
+        ${media.lg} {
+          background-size: auto 80%;
+        }
+      `;
+    }}
+  `,
+  Contents: styled.div`
+    ${({ theme }) => {
+      const { media } = theme;
+      return css`
+        font-size: 20px;
+        line-height: 1.8;
+        font-weight: bold;
+
+        ${media.sm} {
+          font-size: 28px;
+        }
+
+        ${media.md} {
+          font-size: 40px;
+        }
+
+        p {
+          display: flex;
+          align-items: center;
+          margin: 0;
+        }
+      `;
+    }}
+  `,
+  Box: styled.span`
+    ${({ theme }) => {
+      const { media } = theme;
+      return css`
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        flex-direction: column;
+        min-width: 6em;
+        height: 2em;
+        margin-right: 10px;
+        background-color: rgba(0, 0, 0, 0.1);
+        border: 3px solid white;
+        overflow: hidden;
+
+        ${media.sm} {
+          border-width: 5px;
+        }
+      `;
+    }}
+  `,
+  Name: styled.span<{ state: "current" | "prev" | "next" | "hidden" }>`
+    ${({ state }) => {
+      return css`
+        position: absolute;
+        display: block;
+        transition: transform 0.3s;
+
+        ${state === "prev" &&
+        css`
+          transform: translate3d(0, -100%, 0);
+        `}
+
+        ${state === "next" &&
+        css`
+          transform: translate3d(0, 100%, 0);
+        `}
+  
+          ${state === "hidden" &&
+        css`
+          display: none;
+        `}
+      `;
+    }}
+  `,
+};

--- a/components/events/index.tsx
+++ b/components/events/index.tsx
@@ -1,3 +1,16 @@
+import Container from "components/common/Container";
+import styled from "styled-components";
+
 export default function Events() {
-  return <>Events</>;
+  return (
+    <S.Event>
+      <Container>Events</Container>
+    </S.Event>
+  );
 }
+
+const S = {
+  Event: styled.div`
+    min-height: 100vh;
+  `,
+};

--- a/data/banners.ts
+++ b/data/banners.ts
@@ -1,27 +1,27 @@
-import banner1 from '$assets/images/main_banner_1.png';
-import banner2 from '$assets/images/main_banner_2.png';
-import banner3 from '$assets/images/main_banner_3.png';
-import banner4 from '$assets/images/main_banner_4.png';
+import banner1 from "assets/images/main_banner_1.png";
+import banner2 from "assets/images/main_banner_2.png";
+import banner3 from "assets/images/main_banner_3.png";
+import banner4 from "assets/images/main_banner_4.png";
 
 export default [
-	{
-		name: '개발자',
-		image: banner1,
-		bgColor: '#eec522'
-	},
-	{
-		name: '기획자',
-		image: banner2,
-		bgColor: '#75c3cf'
-	},
-	{
-		name: '디자이너',
-		image: banner3,
-		bgColor: '#5640f5'
-	},
-	{
-		name: '마케터',
-		image: banner4,
-		bgColor: '#ff6749'
-	}
+  {
+    name: "개발자",
+    image: banner1,
+    bgColor: "#eec522",
+  },
+  {
+    name: "기획자",
+    image: banner2,
+    bgColor: "#75c3cf",
+  },
+  {
+    name: "디자이너",
+    image: banner3,
+    bgColor: "#5640f5",
+  },
+  {
+    name: "마케터",
+    image: banner4,
+    bgColor: "#ff6749",
+  },
 ];

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -10,6 +10,7 @@ export default createGlobalStyle`
         font-family: Arial, -apple-system, BlinkMacSystemFont, "Segoe UI",
           Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
           sans-serif;
+        min-width: 280px;
         min-height: 100vh;
         background-color: ${colors["dark_1"]};
         color: ${colors["white"]};


### PR DESCRIPTION
### 작업 내용
- 메인 페이지 배너 추가
- 개발자, 기획자, 디자이너, 마케터 가 차례대로 변경 노출되며 인터랙션 효과 추가
   - `currentIndex` 를 상태 관리
   - setInterval 이용해서 2초마다 `currentIndex` 값 변경하고 이 값에 따라 `Name` styled-component 에 `state` 값을 넘김. 이 값을 이용해서 인터랙션 효과 처리
- 반응형 UI 대응
   - global `theme.media` 값에 따라 반응형 UI

### 스크린샷
mobile|tablet|pc
--|--|--
![1](https://user-images.githubusercontent.com/33195744/201469610-4d704604-257c-43e1-96aa-3a11aa81905f.JPG)|![2](https://user-images.githubusercontent.com/33195744/201469612-6bdc0622-3780-4b32-a3e4-8d7d50720674.JPG)|![3](https://user-images.githubusercontent.com/33195744/201469615-5bcc1949-c225-45fe-9ecf-80e36bfd1618.JPG)

### 인터랙션 동작 확인
![1](https://user-images.githubusercontent.com/33195744/201469828-268e0ac2-54ac-4d4d-99d2-5e1d8859eb09.gif)

